### PR TITLE
Roi msgs

### DIFF
--- a/src/hri/body.py
+++ b/src/hri/body.py
@@ -30,8 +30,8 @@ from typing import Optional
 
 try:
     import rospy
-    from sensor_msgs.msg import Image
-    from hri_msgs.msg import NormalizedRegionOfInterest2D, Skeleton2D
+    from sensor_msgs.msg import RegionOfInterest, Image
+    from hri_msgs.msg import Skeleton2D
     from cv_bridge import CvBridge
     from geometry_msgs.msg import TransformStamped
 
@@ -76,7 +76,7 @@ class Body:
         rospy.logdebug("New body detected: " + self.ns)
 
         self._roi_sub = rospy.Subscriber(
-            self.ns + "/roi", NormalizedRegionOfInterest2D, self._on_roi
+            self.ns + "/roi", RegionOfInterest, self._on_roi
         )
 
         self._cropped_sub = rospy.Subscriber(
@@ -101,7 +101,7 @@ class Body:
         return self._valid
 
     def _on_roi(self, msg):
-        self.roi = Rect(msg.xmin, msg.ymin, msg.xmax, msg.ymax)
+        self.roi = Rect(msg.x_offset, msg.y_offset, msg.width, msg.height)
 
     def _on_cropped(self, msg):
         self.cropped = self._cv_bridge.imgmsg_to_cv2(

--- a/src/hri/face.py
+++ b/src/hri/face.py
@@ -30,9 +30,8 @@ from typing import Optional
 
 try:
     import rospy
-    from sensor_msgs.msg import Image
+    from sensor_msgs.msg import RegionOfInterest, Image
     from hri_msgs.msg import (
-        NormalizedRegionOfInterest2D,
         FacialLandmarks,
         SoftBiometrics,
     )
@@ -49,16 +48,11 @@ except ImportError:
 
 
 class Rect:
-    def __init__(self, xmin, ymin, xmax, ymax):
-        self.x = xmin
-        self.y = ymin
-        self.width = xmax - xmin
-        self.height = ymax - ymin
-
-        self.xmin = xmin
-        self.xmax = xmax
-        self.ymin = ymin
-        self.ymax = ymax
+    def __init__(self, x, y, w, h):
+        self.x = x
+        self.y = y
+        self.width = w
+        self.height = h
 
 
 class Face:
@@ -94,7 +88,7 @@ class Face:
         rospy.logdebug("New face detected: " + self.ns)
 
         self._roi_sub = rospy.Subscriber(
-            self.ns + "/roi", NormalizedRegionOfInterest2D, self._on_roi
+            self.ns + "/roi", RegionOfInterest, self._on_roi
         )
 
         self._cropped_sub = rospy.Subscriber(
@@ -129,7 +123,7 @@ class Face:
         return self._valid
 
     def _on_roi(self, msg):
-        self.roi = Rect(msg.xmin, msg.ymin, msg.xmax, msg.ymax)
+        self.roi = Rect(msg.x_offset, msg.y_offset, msg.width, msg.height)
 
     def _on_cropped(self, msg):
         self.cropped = self._cv_bridge.imgmsg_to_cv2(

--- a/src/hri/person.py
+++ b/src/hri/person.py
@@ -133,9 +133,7 @@ class Person:
         return self._valid
 
     def on_face_id(self, msg):
-        #print(msg)
-        #print(self._hrilistener._faces)
-        if msg.data and msg.data in self._hrilistener._faces:
+        if msg.data and self._hrilistener and msg.data in self._hrilistener._faces:
             self.face_id = msg.data
             self.face = self._hrilistener._faces[self.face_id]
         else:
@@ -143,7 +141,7 @@ class Person:
             self.face = None
 
     def on_body_id(self, msg):
-        if msg.data and msg.data in self._hrilistener._bodies:
+        if msg.data and self._hrilistener and msg.data in self._hrilistener._bodies:
             self.body_id = msg.data
             self.body = self._hrilistener._bodies[self.body_id]
         else:
@@ -151,7 +149,7 @@ class Person:
             self.body = None
 
     def on_voice_id(self, msg):
-        if msg.data and msg.data in self._hrilistener._voices:
+        if msg.data and self._hrilistener and msg.data in self._hrilistener._voices:
             self.voice_id = msg.data
             self.voice = self._hrilistener._voices[self.voice_id]
         else:

--- a/src/hri/person.py
+++ b/src/hri/person.py
@@ -133,6 +133,8 @@ class Person:
         return self._valid
 
     def on_face_id(self, msg):
+        #print(msg)
+        #print(self._hrilistener._faces)
         if msg.data and msg.data in self._hrilistener._faces:
             self.face_id = msg.data
             self.face = self._hrilistener._faces[self.face_id]

--- a/test/test_pyhri.py
+++ b/test/test_pyhri.py
@@ -9,7 +9,8 @@ import unittest
 import rospy
 import rostest
 
-from hri_msgs.msg import IdsList, NormalizedRegionOfInterest2D
+from sensor_msgs.msg import RegionOfInterest
+from hri_msgs.msg import IdsList
 from std_msgs.msg import String
 
 import hri
@@ -79,14 +80,14 @@ class TestHRI(unittest.TestCase):
         self.wait()
 
         roi_A_pub = rospy.Publisher(
-            "/humans/faces/A/roi",
-            NormalizedRegionOfInterest2D,
-            queue_size=1,
-            latch=True,
+            "/humans/faces/A/roi", 
+            RegionOfInterest, 
+            queue_size=1, 
+            latch=True
         )
         roi_B_pub = rospy.Publisher(
             "/humans/faces/B/roi",
-            NormalizedRegionOfInterest2D,
+            RegionOfInterest,
             queue_size=1,
             latch=True,
         )
@@ -112,25 +113,25 @@ class TestHRI(unittest.TestCase):
 
         self.assertIsNone(hri_listener.faces["B"].roi)
 
-        roi_B_pub.publish(xmin=0.1)
+        roi_B_pub.publish(width=10)
         self.wait()
         self.assertIsNotNone(hri_listener.faces["B"].roi)
-        self.assertAlmostEqual(hri_listener.faces["B"].roi.xmin, 0.1)
+        self.assertAlmostEqual(hri_listener.faces["B"].roi.width, 10)
 
-        roi_B_pub.publish(xmin=0.2)
+        roi_B_pub.publish(width=20)
         self.wait()
-        self.assertAlmostEqual(hri_listener.faces["B"].roi.xmin, 0.2)
+        self.assertAlmostEqual(hri_listener.faces["B"].roi.width, 20)
 
         # RoI of face A published *before* face A is published in /faces/tracked,
         # but should still get its RoI, as /roi is latched.
-        roi_A_pub.publish(xmin=0.2)
+        roi_A_pub.publish(width=20)
         self.faces_pub.publish(ids=["A", "B"])
         self.wait(delay=0.1)
 
         self.assertEqual(hri_listener.faces["A"].ns, "/humans/faces/A")
-        self.assertAlmostEqual(hri_listener.faces["A"].roi.xmin, 0.2)
+        self.assertAlmostEqual(hri_listener.faces["A"].roi.width, 20)
         self.assertEqual(hri_listener.faces["B"].ns, "/humans/faces/B")
-        self.assertAlmostEqual(hri_listener.faces["A"].roi.xmin, 0.2)
+        self.assertAlmostEqual(hri_listener.faces["A"].roi.width, 20)
 
         hri_listener.close()
 


### PR DESCRIPTION
# Use `sensor_msgs/RegionOfInterest` for ROI (fixes #5)
Solves [this issue](https://github.com/ros4hri/pyhri/issues/5) related to `pyhri` apparently being the only package in the ROS4HRI framework using `hri_msgs/NormalizedRegionOfInterest2D` instead of `sensor_msgs/RegionOfInterest`.

With respect to simply undoing commit https://github.com/ros4hri/pyhri/commit/be95f6a9ed7caf397f532a3d713496451047266e, in `face.py` it also switches from `hri_msgs/NormalizedPointOfInterest2D` to `sensor_msgs/RegionOfInterest` to represent face ROI. 

# Solve `AttributeError` on first detection
Due to `_hrilistener = None` in `__init__` of `person.py`, at the first call to one of the `on_<x>_id` callbacks, the following error was thrown:
```
[ERROR] [1679581959.014495]: bad callback: <bound method Person.on_face_id of <hri.person.Person object at 0x7f1f2f63b520>>
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/luca/hri_ws/src/pyhri/src/hri/person.py", line 138, in on_face_id
    if msg.data and msg.data in self._hrilistener._faces:
AttributeError: 'NoneType' object has no attribute '_faces'
```
due to the `_hrilistener` attribute being not set by `hri.py` yet. The error do not cause any major issues, as everything work just smoothly from the second detection on.
It has been fixed by adding a `and self._hrilistener is not None` check in each `on_<x>_id` callbacks.